### PR TITLE
Fix CI Pipeline & Add Release Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Build project
       run: npm run build
       
-    - name: Run Tests (placeholder)
+    - name: Run Tests
+      env:
+        STITCH_API_KEY: ${{ secrets.STITCH_API_KEY }}
       run: npm run test
-      # Optionally, if we add pure unit tests: run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release and Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        
+      # You can uncomment this step once you have an NPM_TOKEN set in your GitHub secrets
+      # - name: Publish to NPM
+      #   run: npm publish --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  create-github-release:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Description
Fixes the CI pipeline by dynamically injecting the API Key secret into Vitest.
Adds semantic release automation via GitHub Actions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by injecting the API key so `vitest` runs reliably in CI. Adds a tag-triggered release workflow that builds and creates GitHub releases, with an optional NPM publish step.

- **Bug Fixes**
  - Inject `STITCH_API_KEY` into the CI "Run Tests" step to unblock `vitest`.

- **New Features**
  - Add `Release and Publish` workflow triggered by `v*.*.*` tags to build and create GitHub Releases with generated notes.
  - Include an optional `npm publish` step (disabled until `NPM_TOKEN` is configured).

<sup>Written for commit 9302afdd5912c2e48b7db34363dd0933af69bf8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

