### PR TITLE
fix(ci): Remove Node 18.x from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Vitest/rolldown requires 
ode:util styleText which was added in Node 20.12.0. This drops Node 18 from the CI matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Node 18.x from the CI matrix to avoid test failures. `vitest`/`rolldown` rely on `util.styleText`, which is available only in Node >=20.12.

- **Migration**
  - Use Node 20.12+ locally (20.x or 22.x) to run tests and builds.

<sup>Written for commit aa3899499c61fb06d632729e89f4c087153cd729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

