### PR TITLE
feat: Interactive Setup CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "@google/stitch-sdk": "^0.0.3",
+        "@inquirer/prompts": "^8.3.2",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "dotenv": "^17.3.1",
         "zod": "^4.3.6"
       },
       "bin": {
-        "stitch-mcp": "dist/index.js"
+        "stitch-mcp": "dist/index.js",
+        "stitch-mcp-setup": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -523,6 +525,334 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
+      "integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
+      "integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
+      "integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
+      "integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
+      "integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/external-editor": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
+      "integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
+      "integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
+      "integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
+      "integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
+      "integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
+      "integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
+      "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.1.2",
+        "@inquirer/confirm": "^6.0.10",
+        "@inquirer/editor": "^5.0.10",
+        "@inquirer/expand": "^5.0.10",
+        "@inquirer/input": "^5.0.10",
+        "@inquirer/number": "^4.0.10",
+        "@inquirer/password": "^5.0.10",
+        "@inquirer/rawlist": "^5.2.6",
+        "@inquirer/search": "^4.1.6",
+        "@inquirer/select": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
+      "integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
+      "integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
+      "integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
+      "integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1300,7 +1630,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1594,6 +1924,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1608,6 +1944,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/commander": {
@@ -1996,6 +2341,21 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2011,6 +2371,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2666,6 +3035,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -3256,6 +3634,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3513,7 +3903,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "type": "module",
   "dependencies": {
     "@google/stitch-sdk": "^0.0.3",
+    "@inquirer/prompts": "^8.3.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "dotenv": "^17.3.1",
     "zod": "^4.3.6"
@@ -39,6 +40,7 @@
     "vitest": "^4.1.0"
   },
   "bin": {
-    "stitch-mcp": "dist/index.js"
+    "stitch-mcp": "dist/index.js",
+    "stitch-mcp-setup": "dist/cli.js"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runSetup } from "./setup.js";
+
+runSetup().catch((err) => {
+  console.error("An error occurred during setup:", err);
+  process.exit(1);
+});

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,133 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { checkbox, input, confirm } from "@inquirer/prompts";
+
+const homedir = os.homedir();
+const platform = os.platform();
+
+const getAppDataPath = () => {
+  if (platform === "win32") {
+    return process.env.APPDATA || path.join(homedir, "AppData", "Roaming");
+  } else if (platform === "darwin") {
+    return path.join(homedir, "Library", "Application Support");
+  } else {
+    return path.join(homedir, ".config");
+  }
+};
+
+const getClaudeDesktopConfigPath = () => {
+  if (platform === "darwin") {
+    return path.join(homedir, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+  }
+  return path.join(getAppDataPath(), "Claude", "claude_desktop_config.json");
+};
+
+const getClineConfigPath = () => {
+  if (platform === "darwin") {
+    return path.join(homedir, "Library", "Application Support", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+  } else if (platform === "win32") {
+    return path.join(getAppDataPath(), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+  }
+  return path.join(getAppDataPath(), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+};
+
+const getCursorConfigDir = () => {
+  // Cursor usually configures MCP via the UI which stores in its SQLite DB or in workspace .cursor/mcp.json. 
+  // However, we can create a `.cursor/mcp.json` in the user's home directory if they want a start. 
+  // Or we can just prompt them to set it up in the UI.
+  return path.join(homedir, ".cursor");
+};
+
+export const runSetup = async () => {
+  console.log("\n🚀 Welcome to the Stitch MCP Server Setup!");
+  console.log("This utility will automatically configure your favorite tools to use the Stitch MCP Server.\n");
+
+  const tools = [
+    {
+      name: "Claude Desktop",
+      value: "claude",
+      checked: fs.existsSync(getClaudeDesktopConfigPath()),
+    },
+    {
+      name: "Cline (VS Code Extension)",
+      value: "cline",
+      checked: fs.existsSync(getClineConfigPath()),
+    },
+    {
+      name: "Cursor (Workspace Config)",
+      value: "cursor",
+      checked: fs.existsSync(getCursorConfigDir()),
+    }
+  ];
+
+  const selectedTools = await checkbox({
+    message: "Which tools would you like to configure this MCP Server for?",
+    choices: tools,
+  });
+
+  if (selectedTools.length === 0) {
+    console.log("❌ No tools selected. Exiting.");
+    return;
+  }
+
+  const apiKey = await input({
+    message: "Please enter your Stitch API Key (STITCH_API_KEY):",
+  });
+
+  if (!apiKey) {
+    console.log("❌ API Key is required. Exiting.");
+    return;
+  }
+
+  console.log("\nConfiguring selected tools...\n");
+
+  const serverCommand = platform === "win32" ? "npx.cmd" : "npx";
+  const serverArgs = ["-y", "stitch-mcp-server"];
+
+  const mcpConfigEntry = {
+    command: serverCommand,
+    args: serverArgs,
+    env: {
+      STITCH_API_KEY: apiKey
+    }
+  };
+
+  const updateJsonConfig = (configPath: string, keyName: string = "stitch", serverDef = mcpConfigEntry) => {
+    let config: any = { mcpServers: {} };
+    try {
+      if (fs.existsSync(configPath)) {
+        const fileContent = fs.readFileSync(configPath, "utf-8");
+        config = JSON.parse(fileContent);
+        if (!config.mcpServers) config.mcpServers = {};
+      } else {
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      }
+      
+      config.mcpServers[keyName] = serverDef;
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      console.log(`✅ Successfully updated: ${configPath}`);
+    } catch (err) {
+      console.error(`❌ Failed to update ${configPath}:`, err);
+    }
+  };
+
+  for (const tool of selectedTools) {
+    if (tool === "claude") {
+      updateJsonConfig(getClaudeDesktopConfigPath());
+    } else if (tool === "cline") {
+      updateJsonConfig(getClineConfigPath());
+    } else if (tool === "cursor") {
+      // Create a global or workspace .cursor/mcp.json snippet
+      const cursorPath = path.join(process.cwd(), ".cursor", "mcp.json");
+      console.log(`\n💡 Note: Cursor handles MCP per-workspace or via its UI Settings.`);
+      console.log(`Generating workspace config for Cursor at ${cursorPath}`);
+      updateJsonConfig(cursorPath);
+      console.log(`👉 In Cursor: Go to Cursor Settings Menu > Settings > Features > MCP to manage servers visually.`);
+    }
+  }
+
+  console.log("\n🎉 Setup complete! You can now use Stitch-mcp-server in your selected tools.");
+  console.log("Make sure to restart Claude Desktop or reload your Editor for changes to take effect.");
+};
+

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/cli.ts'],
   format: ['esm'],
   dts: true,
   clean: true,


### PR DESCRIPTION
Adds \stitch-mcp-setup\ bin wrapper to prompt users for tools and api keys and modify MCP JSON configs automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an interactive setup CLI `stitch-mcp-setup` that configures Claude Desktop, Cline, and Cursor to use the Stitch MCP server by prompting for tools and your `STITCH_API_KEY`, then updating their JSON configs. This removes manual edits and works on macOS, Windows, and Linux.

- **New Features**
  - Adds `stitch-mcp-setup` (bin: `dist/cli.js`) using `@inquirer/prompts` for a guided setup.
  - Auto-writes MCP server config using `npx -y stitch-mcp-server` with `STITCH_API_KEY` to the correct paths for Claude Desktop and Cline; generates `.cursor/mcp.json` for Cursor workspaces.
  - Updates build to include the CLI entry in `tsup.config.ts` and exposes the new bin in `package.json`.

- **Migration**
  - Run: `npx stitch-mcp-setup` and follow the prompts.
  - Restart Claude Desktop or reload your editor for changes to take effect.

<sup>Written for commit ae15d4b77445b6d4cc4f213a3061ba1e2c22dea0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

