### PR TITLE
fix: setup tweaks and README guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,32 @@ This server acts as a bridge between your coding agent (Claude, Gemini, Copilot,
 - **Context Resources**: Map abstract IDs natively with `stitch://projects` and `stitch://projects/{projectId}/screens` context providers.
 - **Bootstrapping Prompts**: Leverage the native `create_web_app` prompt for zero-shot orchestration to guide agents from project creation to scaffolding.
 
-## Setup
+## Installation & Setup
 
-You need an active `STITCH_API_KEY` to run this server. 
+You need an active `STITCH_API_KEY` to run this server. You can sign up with your Google account to get one.
 
-### Global Execution (npx)
+This package comes with a built-in automated installer for **Claude Desktop**, **Cline**, and **Cursor**.
+
+### The Easy Way (Interactive Setup)
+
+Run the following command anywhere on your machine. It will ask which AI tools you want to configure, and it will safely insert the server and prompt you for your `STITCH_API_KEY`:
+
+```bash
+npx -y stitch-mcp-server@latest setup
+```
+
+That's it! Restart your target application and the tools will appear.
+
+### The Manual Way (JSON Config)
+
+If you prefer to configure your client manually, use the following snippet. Ensure you replace `your-api-key` with your actual Stitch API Key.
+
 ```json
 {
   "mcpServers": {
-    "stitch-mcp": {
+    "stitch": {
       "command": "npx",
-      "args": ["stitch-mcp-server"],
+      "args": ["-y", "stitch-mcp-server@latest"],
       "env": {
         "STITCH_API_KEY": "your-api-key"
       }
@@ -33,6 +48,12 @@ You need an active `STITCH_API_KEY` to run this server.
   }
 }
 ```
+
+---
+
+## Capabilities
+
+The `stitch-mcp-server` gives your AI assistant several specialized tools:
 
 ### Local Development
 1. Install dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,5 +3,5 @@ import { runSetup } from "./setup.js";
 
 runSetup().catch((err) => {
   console.error("An error occurred during setup:", err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -32,11 +32,8 @@ const getClineConfigPath = () => {
   return path.join(getAppDataPath(), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
 };
 
-const getCursorConfigDir = () => {
-  // Cursor usually configures MCP via the UI which stores in its SQLite DB or in workspace .cursor/mcp.json. 
-  // However, we can create a `.cursor/mcp.json` in the user's home directory if they want a start. 
-  // Or we can just prompt them to set it up in the UI.
-  return path.join(homedir, ".cursor");
+const getCursorConfigPath = () => {
+  return path.join(process.cwd(), ".cursor", "mcp.json");
 };
 
 export const runSetup = async () => {
@@ -57,7 +54,7 @@ export const runSetup = async () => {
     {
       name: "Cursor (Workspace Config)",
       value: "cursor",
-      checked: fs.existsSync(getCursorConfigDir()),
+      checked: fs.existsSync(getCursorConfigPath()),
     }
   ];
 
@@ -118,8 +115,7 @@ export const runSetup = async () => {
     } else if (tool === "cline") {
       updateJsonConfig(getClineConfigPath());
     } else if (tool === "cursor") {
-      // Create a global or workspace .cursor/mcp.json snippet
-      const cursorPath = path.join(process.cwd(), ".cursor", "mcp.json");
+      const cursorPath = getCursorConfigPath();
       console.log(`\n💡 Note: Cursor handles MCP per-workspace or via its UI Settings.`);
       console.log(`Generating workspace config for Cursor at ${cursorPath}`);
       updateJsonConfig(cursorPath);


### PR DESCRIPTION
Updates process.exitCode on errors rather than outright aborting, scopes the Cursor mcp JSON properly, and completely rewrites the README for public NPM consumption.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves setup reliability and clarifies installation for `stitch-mcp-server`. Uses `process.exitCode` to avoid abrupt exits, fixes Cursor workspace config path, and rewrites the README with an interactive setup flow and corrected manual JSON.

- **Bug Fixes**
  - Use `process.exitCode = 1` instead of `process.exit(1)` to prevent truncation on errors.
  - Scope Cursor config to workspace `.cursor/mcp.json` and update detection to that path.

- **Migration**
  - Run `npx -y stitch-mcp-server@latest setup` for interactive install.
  - For manual config, use `mcpServers.stitch` with args `["-y", "stitch-mcp-server@latest"]` and set `STITCH_API_KEY`.
  - For Cursor, place config at `.cursor/mcp.json` in the workspace.

<sup>Written for commit 7d91bc0829560e92707df71907740ceb2e4ef885. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

