### PR TITLE
fix: handle massive payload crash and add manual config fallback

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -19,8 +19,14 @@ export function registerTools(server: McpServer) {
     async ({ title }) => {
       try {
         const result = await toolClient.callTool("create_project", { title });
+        
+        let outputText = JSON.stringify(result, null, 2);
+        if (outputText.length > 3000) {
+          outputText = outputText.substring(0, 3000) + "\n...[Content truncated to prevent context overflow]...";
+        }
+
         return {
-          content: [{ type: "text", text: `Project created successfully!\n\n${JSON.stringify(result, null, 2)}` }],
+          content: [{ type: "text", text: `Project created successfully!\n\n${outputText}` }],
         };
       } catch (error: any) {
         return { content: [{ type: "text", text: `Error creating project: ${error?.message || String(error)}` }], isError: true };

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -65,46 +65,18 @@ export const runSetup = async () => {
   console.log("\nWelcome to the Stitch MCP Server Setup");
   console.log("This utility will automatically configure your favorite tools to use the Stitch MCP Server.\n");
 
-  // Detect which tools are installed/available
   const claudeInstalled = fs.existsSync(path.dirname(getClaudeDesktopConfigPath()));
   const clineInstalled = fs.existsSync(path.dirname(getClineConfigPath()));
-  
-  const tools = [
-    {
-      name: `Claude Desktop${claudeInstalled ? "" : " (not detected)"}`,
-      value: "claude",
-      checked: claudeInstalled,
-    },
-    {
-      name: `Cline (VS Code Extension)${clineInstalled ? "" : " (not detected)"}`,
-      value: "cline",
-      checked: clineInstalled,
-    },
-    {
-      name: "Cursor (Workspace Config)",
-      value: "cursor",
-      checked: false,
-    }
-  ];
+  const cursorInstalled = fs.existsSync(path.join(process.cwd(), ".cursor"));
 
-  let selectedTools: string[];
-  try {
-    selectedTools = await checkbox({
-      message: "Which tools would you like to configure this MCP Server for?",
-      choices: tools,
-    });
-  } catch (err: unknown) {
-    // Handle user cancellation (Ctrl+C)
-    if (err && typeof err === 'object' && 'name' in err && err.name === 'ExitPromptError') {
-      console.log("\nSetup cancelled by user.");
-      return;
-    }
-    throw err;
-  }
+  const availableTools: string[] = [];
+  if (claudeInstalled) availableTools.push("Claude Desktop");
+  if (clineInstalled) availableTools.push("Cline AI");
+  if (cursorInstalled) availableTools.push("Cursor");
 
-  if (selectedTools.length === 0) {
-    console.log("No tools selected. Exiting.");
-    return;
+  if (availableTools.length === 0) {
+    console.log("No automatically configurable AI apps detected on this system.");
+    console.log("We will provide you with the JSON configuration you can manually paste into your MCP settings.\n");
   }
 
   let apiKey: string;
@@ -131,8 +103,6 @@ export const runSetup = async () => {
 
   apiKey = apiKey.trim();
 
-  console.log("\nConfiguring selected tools...\n");
-
   const serverCommand = platform === "win32" ? "npx.cmd" : "npx";
   const serverArgs = ["-y", "stitch-mcp-server@latest"];
 
@@ -143,6 +113,63 @@ export const runSetup = async () => {
       STITCH_API_KEY: apiKey
     }
   };
+
+  if (availableTools.length === 0) {
+    console.log("\n================ MCP CONFIGURATION ================\n");
+    console.log(JSON.stringify({
+      mcpServers: {
+        "stitch": mcpConfigEntry
+      }
+    }, null, 2));
+    console.log("\n===================================================\n");
+    console.log("Please copy the JSON above and paste it into your app's MCP settings.");
+    return;
+  }
+
+  const tools = [
+    {
+      name: `Claude Desktop${claudeInstalled ? "" : " (not detected)"}`,
+      value: "claude",
+      checked: claudeInstalled,
+    },
+    {
+      name: `Cline (VS Code Extension)${clineInstalled ? "" : " (not detected)"}`,
+      value: "cline",
+      checked: clineInstalled,
+    },
+    {
+      name: "Cursor (Workspace Config)",
+      value: "cursor",
+      checked: cursorInstalled,
+    }
+  ];
+
+  let selectedTools: string[];
+  try {
+    selectedTools = await checkbox({
+      message: "Which tools would you like to configure this MCP Server for?",
+      choices: tools,
+    });
+  } catch (err: unknown) {
+    // Handle user cancellation (Ctrl+C)
+    if (err && typeof err === 'object' && 'name' in err && err.name === 'ExitPromptError') {
+      console.log("\nSetup cancelled by user.");
+      return;
+    }
+    throw err;
+  }
+
+  if (selectedTools.length === 0) {
+    console.log("\nNo tools selected. Here is your raw configuration:\n");
+    console.log(JSON.stringify({
+      mcpServers: {
+        "stitch": mcpConfigEntry
+      }
+    }, null, 2));
+    return;
+  }
+
+  console.log("\nConfiguring selected tools...\n");
 
   const updateJsonConfig = (configPath: string, keyName: string = "stitch", serverDef = mcpConfigEntry): boolean => {
     let config: { mcpServers: Record<string, unknown> } = { mcpServers: {} };


### PR DESCRIPTION
I looked into the problem reported in #13 where the agent crashes because of the huge JSON blob. I've added a truncation mechanism so we only send the first 3000 characters of the project data to the LLM to prevent the context window from blowing up. Also, I updated the CLI installer so that if a user doesn't have Claude, Cursor, or Cline installed, it doesn't just fail—it prints out the raw JSON config so you can manually copy-paste it for other clients. This should make the DX much smoother. Closes #13.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes from oversized project payloads by truncating output to 3000 chars, and adds a setup fallback that prints a copy‑paste MCP JSON when no supported app is detected. Fixes #13.

- **Bug Fixes**
  - Truncate `create_project` response to 3000 characters with a clear “[Content truncated…]” notice to avoid context overflow and crashes.

- **New Features**
  - Setup prints a ready-to-paste MCP JSON config if no supported app is found or no tools are selected.
  - Detects `Cursor` workspaces (`.cursor`) and includes it in selectable tools during setup.

<sup>Written for commit fb13755237827e4f06d6820d809d8a9723382731. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

