### PR TITLE
fix: remove dotenv from production boot to prevent stdout pollution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@google/stitch-sdk": "^0.0.3",
         "@inquirer/prompts": "^8.3.2",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "dotenv": "^17.3.1",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -22,6 +21,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "dotenv": "^17.3.1",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
@@ -1985,6 +1985,8 @@
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
       "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
     "@google/stitch-sdk": "^0.0.3",
     "@inquirer/prompts": "^8.3.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "dotenv": "^17.3.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "dotenv": "^17.3.1",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,9 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import dotenv from "dotenv";
 import { registerTools } from "./handlers/tools.js";
 import { registerResources } from "./handlers/resources.js";
 import { registerPrompts } from "./handlers/prompts.js";
-
-// Load environment variables
-dotenv.config();
 
 // Check for setup subcommand
 const args = process.argv.slice(2);


### PR DESCRIPTION
I found that the new \dotenv\ update forcefully logs telemetry like \[dotenv@17.3.1] injecting env...\ directly to standard output. Since MCP communicates via pure JSON-RPC over stdout, this logging completely breaks the protocol handshake for agents like Claude Desktop. 

I've completely removed the \dotenv.config()\ call from our main server process since environment variables like \STITCH_API_KEY\ are passed down directly by the MCP clients anyway. I kept \dotenv\ loosely around in devDependencies so my local test suite still passes.

Closes whatever remaining handshake corruption issues we have.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `dotenv` from production startup to stop stdout logs that corrupted the MCP JSON-RPC handshake. Runtime env vars are passed by MCP clients; `dotenv` is kept only for local dev.

- **Bug Fixes**
  - Removed `dotenv.config()` in `src/index.ts` to prevent stdout noise that breaks stdio transport (e.g., Claude Desktop).

- **Dependencies**
  - Moved `dotenv` from dependencies to devDependencies.

<sup>Written for commit 58e1d1dbee88f8505aafb7299f7d6d92018b3568. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Environment variables must now be provided externally at runtime rather than automatically loaded during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->